### PR TITLE
Add the ocs-bridge and mcm services

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,24 +1,57 @@
 class ccs_sal::service {
 
-  $setupfile = '/etc/ccs/setup-sal5'
-
-  $epp_vars = {
-    desc    => 'OpenSpliceDDS daemons',
+  $common_vars = {
     user    => 'ccs',
     group   => 'ccs',
     workdir => '/home/ccs',
-    env     => 'LSST_DDS_RESPONSIVENESS_TIMEOUT=15s',
-    start   => "/bin/bash -c 'source ${setupfile} && \$OSPL_HOME/bin/ospl -f start'",
-    stop    => "/bin/bash -c 'source ${setupfile} && \$OSPL_HOME/bin/ospl stop'",
   }
 
-  $service = 'opensplice'
+  $instrument = $ccs_sal::instrument
 
-  systemd::unit_file { "${service}.service":
-    content => epp("${module_name}/${service}.service.epp", $epp_vars),
+  $sal_file = '/etc/ccs/setup-sal5'
+
+  $opensplice = {
+    service  => 'opensplice',
+    template => 'opensplice',
+    vars     => {
+      desc  => 'OpenSpliceDDS daemons',
+      env   => 'LSST_DDS_RESPONSIVENESS_TIMEOUT=15s',
+      start => "/bin/bash -c 'source ${sal_file} && \$OSPL_HOME/bin/ospl -f start'",
+      stop  => "/bin/bash -c 'source ${sal_file} && \$OSPL_HOME/bin/ospl stop'",
+    }
   }
-  -> service { $service:
-    enable => true,
+
+  $ocs_bridge = {
+    service  => "ocs-bridge-${instrument}",
+    template => 'ocs-bridge',
+    vars     => {
+      desc  => "CCS OCS bridge for ${instrument}",
+      env   => 'LSST_DDS_HISTORYSYNC=0',
+      start => "/opt/lsst/ccs/prod/bin/ocs-bridge-${instrument}",
+    }
+  }
+
+  $mcm = {
+    service  => "mcm-${instrument}",
+    template => 'mcm',
+    vars     => {
+      desc    => "CCS MCM for ${instrument}",
+      start   => "/opt/lsst/ccs/prod/bin/mcm-${instrument}",
+    }
+  }
+
+  $services = [$opensplice, $ocs_bridge, $mcm]
+
+  $services.each | $hash | {
+    $service  = $hash['service']
+    $template = $hash['template']
+    $epp_vars = $common_vars + $hash['vars']
+    systemd::unit_file { "${service}.service":
+      content => epp("${module_name}/service.epp", $epp_vars),
+    }
+    -> service { $service:
+      enable => true,
+    }
   }
 
 }

--- a/templates/service.epp
+++ b/templates/service.epp
@@ -2,9 +2,9 @@
       String $user,
       String $group,
       String $start,
-      String $stop,
+      Optional[String] $stop = undef,
       String $workdir,
-      String $env
+      Optional[String] $env = undef
 | -%>
 # This file is managed by Puppet; changes may be overwritten.
 [Unit]
@@ -15,9 +15,13 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=<%= $workdir %>
+<% unless $env =~ Undef { -%>
 Environment=<%= $env %>
+<% } -%>
 ExecStart=<%= $start %>
+<% unless $stop =~ Undef { -%>
 ExecStop=<%= $stop %>
+<% } -%>
 Restart=on-failure
 RestartSec=42s
 User=<%= $user %>


### PR DESCRIPTION
This adds the ocs-bridge and mcm services. It only adds the "/prod" versions, assuming that "systemctl edit" is used for any local modifications.