### PR TITLE
Split rpms and their yum repos into private and public

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,18 +12,26 @@
 ##   String giving name of SAL interface (eg somehost-dds)
 ## @param instrument
 ##   String giving instrument (eg comcam).
-## @param rpm_repo, rpm_user, rpm_pass
-##   Strings giving repo url, username and password for rpm download.
+## @param rpm_repo
+##   String giving repo url for rpm download
+## @param rpms_private
+##   Optional hash of rpms to download from private repo.
+## @param rpm_repo_private, rpm_user, rpm_pass
+##   Optional strings giving private rpm repo, username and password
 
 class ccs_sal (
-  Hash[String,String,2] $rpms,
+  Hash[String,String,1] $rpms,
   ## Change the following in hiera, not here.
   String $ospl_home = '/opt/OpenSpliceDDS/VX.Y.Z/example/example',
   String $dds_domain = 'summit',
   String $dds_interface = 'localhost-dds',
   String $instrument = 'comcam',
   ## Old: http://www.slac.stanford.edu/~gmorris/lsst/pkgarchive
-  String $rpm_repo = 'https://repo-nexus.lsst.org/nexus/repository/ts_yum_private/releases',
+  String $rpm_repo = 'https://repo-nexus.lsst.org/nexus/repository/ts_yum/releases',
+  ## If specified, rpms to fetch from _private repo using _user and _pass.
+  Hash[String,String] $rpms_private = {},
+  ## Defaults to _repo with yum -> yum_private.
+  Optional[String] $rpm_repo_private = undef,
   ## In lsst-puppet-hiera-private.
   Optional[String] $rpm_user = undef,
   Optional[String] $rpm_pass = undef,

--- a/manifests/rpms.pp
+++ b/manifests/rpms.pp
@@ -3,9 +3,17 @@ class ccs_sal::rpms {
   ## Needed by ts_sal_utils.
   ensure_packages(['linuxptp'])
 
+  ## Public rpms.
   $repo = $ccs_sal::rpm_repo
-  $user = $ccs_sal::rpm_user
-  $pass = $ccs_sal::rpm_pass
+
+  $rpm_opts = {
+    ensure       => 'latest',
+    provider     => 'rpm',
+    ## Following allows us to have multiple versions installed.
+    ## Must include the version+release in the package name.
+    ## Eg instead of "OpenSpliceDDS", use "OpenSpliceDDS-6.11.0-16.el7".
+    install_only => true,
+  }
 
   $ccs_sal::rpms.each |$package, $rpm| {
 
@@ -15,25 +23,38 @@ class ccs_sal::rpms {
       ensure => present,
       source => "${repo}/${rpm}",
     }
-    if $user !~ Undef {
-      Archive[$file] {
-        username => $user,
-      }
+    package { $package:
+      source => $file,
+      *      => $rpm_opts,
     }
-    if $pass !~ Undef {
-      Archive[$file] {
-        password => $pass,
-      }
+  }
+
+
+  ## Private rpms.
+  $repo_private0 = $ccs_sal::rpm_repo_private
+  if $repo_private0 !~ Undef {
+    $repo_private = $repo_private0
+  } else {
+    $repo_private = regsubst($repo, 'yum', 'yum_private')
+  }
+
+  $user = $ccs_sal::rpm_user
+  $pass = $ccs_sal::rpm_pass
+
+  $ccs_sal::rpms_private.each |$package, $rpm| {
+
+    $file = "/var/tmp/${rpm}"
+
+    archive { $file:
+      ensure   => present,
+      source   => "${repo_private}/${rpm}",
+      username => $user,
+      password => $pass,
     }
 
     package { $package:
-      ensure       => 'latest',
-      provider     => 'rpm',
-      source       => $file,
-      ## Following allows us to have multiple versions installed.
-      ## Must include the version+release in the package name.
-      ## Eg instead of "OpenSpliceDDS", use "OpenSpliceDDS-6.11.0-16.el7".
-      install_only => true,
+      source => $file,
+      *      => $rpm_opts,
     }
   }
 


### PR DESCRIPTION
Class parameter hash rpms now only requires >= 1 member.
New parameters: rpms_private, rpm_repo_private.
In rpms.pp, treat public and private rpms differently.
The latter are fetched from a different repo, with username and password.