### PR TITLE
Add option to not apply instrument- prefix to service names

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,9 +7,9 @@
 ### Classes
 
 * [`ccs_sal`](#ccs_sal): Install stuff for CCS/SAL gateway.
-* [`ccs_sal::etc`](#ccs_sal--etc)
-* [`ccs_sal::rpms`](#ccs_sal--rpms)
-* [`ccs_sal::service`](#ccs_sal--service)
+* [`ccs_sal::etc`](#ccs_sal--etc): Configure /etc for CCS/SAL
+* [`ccs_sal::rpms`](#ccs_sal--rpms): Install rpms needed by CCS/SAL
+* [`ccs_sal::service`](#ccs_sal--service): Manage systemd service files for CCS/SAL
 
 ## Classes
 
@@ -26,6 +26,7 @@ The following parameters are available in the `ccs_sal` class:
 * [`dds_domain`](#-ccs_sal--dds_domain)
 * [`dds_interface`](#-ccs_sal--dds_interface)
 * [`instrument`](#-ccs_sal--instrument)
+* [`prefix_service`](#-ccs_sal--prefix_service)
 * [`rpm_repo`](#-ccs_sal--rpm_repo)
 * [`rpms_private`](#-ccs_sal--rpms_private)
 * [`rpm_repo_private`](#-ccs_sal--rpm_repo_private)
@@ -71,6 +72,14 @@ String giving instrument (eg comcam).
 
 Default value: `'comcam'`
 
+##### <a name="-ccs_sal--prefix_service"></a>`prefix_service`
+
+Data type: `Boolean`
+
+Boolean; if false do not prefix systemctl services with the instrument.
+
+Default value: `true`
+
 ##### <a name="-ccs_sal--rpm_repo"></a>`rpm_repo`
 
 Data type: `String`
@@ -113,13 +122,13 @@ Default value: `undef`
 
 ### <a name="ccs_sal--etc"></a>`ccs_sal::etc`
 
-The ccs_sal::etc class.
+Configure /etc for CCS/SAL
 
 ### <a name="ccs_sal--rpms"></a>`ccs_sal::rpms`
 
-The ccs_sal::rpms class.
+Install rpms needed by CCS/SAL
 
 ### <a name="ccs_sal--service"></a>`ccs_sal::service`
 
-The ccs_sal::service class.
+Manage systemd service files for CCS/SAL
 

--- a/examples/basic.pp
+++ b/examples/basic.pp
@@ -13,6 +13,6 @@ group { 'ccsadm':
 
 class { 'ccs_sal':
   rpms => {
-    ts_sal_utils => 'ts_sal_utils-7.0.0-1.x86_64.rpm',
+    ts_sal_utils => 'ts_sal_utils-7.4.0-1.x86_64.rpm',
   },
 }

--- a/manifests/etc.pp
+++ b/manifests/etc.pp
@@ -1,3 +1,6 @@
+# @summary
+#   Configure /etc for CCS/SAL
+#
 class ccs_sal::etc {
   $dir = '/etc/ccs'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 #   String giving name of SAL interface (eg somehost-dds)
 # @param instrument
 #   String giving instrument (eg comcam).
+# @param prefix_service
+#   Boolean; if false do not prefix systemctl services with the instrument.
 # @param rpm_repo
 #   String giving repo url for rpm download
 # @param rpms_private
@@ -30,6 +32,7 @@ class ccs_sal (
   String $dds_domain = 'summit',
   String $dds_interface = 'localhost-dds',
   String $instrument = 'comcam',
+  Boolean $prefix_service = true,
   ## Old: http://www.slac.stanford.edu/~gmorris/lsst/pkgarchive
   String $rpm_repo = 'https://repo-nexus.lsst.org/nexus/repository/ts_yum/releases',
   ## If specified, rpms to fetch from _private repo using _user and _pass.

--- a/manifests/rpms.pp
+++ b/manifests/rpms.pp
@@ -1,3 +1,6 @@
+# @summary
+#   Install rpms needed by CCS/SAL
+#
 class ccs_sal::rpms {
   ## Needed by ts_sal_utils.
   ensure_packages(['linuxptp'])

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,3 +1,6 @@
+# @summary
+#   Manage systemd service files for CCS/SAL
+#
 class ccs_sal::service {
   $common_vars = {
     user    => 'ccs',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,6 +6,13 @@ class ccs_sal::service {
   }
 
   $instrument = $ccs_sal::instrument
+  $prefix_service = $ccs_sal::prefix_service
+
+  if $prefix_service {
+    $prefix = "${instrument}-"
+  } else {
+    $prefix = ''
+  }
 
   $sal_file = '/etc/ccs/setup-sal5'
 
@@ -21,20 +28,20 @@ class ccs_sal::service {
 
   ## 202107: Name changed from ocs-bridge-${instrument}
   $ocs_bridge = {
-    service  => "${instrument}-ocs-bridge",
+    service  => "${prefix}ocs-bridge",
     vars     => {
-      desc  => "CCS OCS bridge for ${instrument}",
+      desc  => 'CCS OCS bridge service',
       env   => ['LSST_DDS_HISTORYSYNC=0'],
-      start => "/opt/lsst/ccs/prod/bin/${instrument}-ocs-bridge",
+      start => "/opt/lsst/ccs/prod/bin/${prefix}ocs-bridge",
     },
   }
 
   ## 202107: Name changed from mcm-${instrument}
   $mcm = {
-    service  => "${instrument}-mcm",
+    service  => "${prefix}mcm",
     vars     => {
-      desc    => "CCS MCM for ${instrument}",
-      start   => "/opt/lsst/ccs/prod/bin/${instrument}-mcm",
+      desc    => 'CCS MCM service',
+      start   => "/opt/lsst/ccs/prod/bin/${prefix}mcm",
     },
   }
 


### PR DESCRIPTION
This adds a new option prefix_service, true by default. Necessary because for some reason on lsstcam hosts services are being defined without the prefix, in contrast to eg comcam, which does use the prefix.