### PR TITLE
Add option to use kafka instead of dds

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,9 +23,16 @@ The following parameters are available in the `ccs_sal` class:
 
 * [`rpms`](#-ccs_sal--rpms)
 * [`ospl_home`](#-ccs_sal--ospl_home)
+* [`dds`](#-ccs_sal--dds)
 * [`dds_domain`](#-ccs_sal--dds_domain)
 * [`dds_interface`](#-ccs_sal--dds_interface)
 * [`instrument`](#-ccs_sal--instrument)
+* [`kafka`](#-ccs_sal--kafka)
+* [`kafka_broker_address`](#-ccs_sal--kafka_broker_address)
+* [`kafka_registry_url`](#-ccs_sal--kafka_registry_url)
+* [`kafka_sasl_username`](#-ccs_sal--kafka_sasl_username)
+* [`kafka_sasl_password`](#-ccs_sal--kafka_sasl_password)
+* [`kafka_templates_directory`](#-ccs_sal--kafka_templates_directory)
 * [`prefix_service`](#-ccs_sal--prefix_service)
 * [`rpm_repo`](#-ccs_sal--rpm_repo)
 * [`rpms_private`](#-ccs_sal--rpms_private)
@@ -47,6 +54,14 @@ Data type: `String`
 String giving OSPL_HOME.
 
 Default value: `'/opt/OpenSpliceDDS/VX.Y.Z/example/example'`
+
+##### <a name="-ccs_sal--dds"></a>`dds`
+
+Data type: `Boolean`
+
+Boolean; if true install DDS support
+
+Default value: `true`
 
 ##### <a name="-ccs_sal--dds_domain"></a>`dds_domain`
 
@@ -71,6 +86,55 @@ Data type: `String`
 String giving instrument (eg comcam).
 
 Default value: `'comcam'`
+
+##### <a name="-ccs_sal--kafka"></a>`kafka`
+
+Data type: `Boolean`
+
+Boolean; if true install Kafka support
+kafka will be used.
+
+Default value: `false`
+
+##### <a name="-ccs_sal--kafka_broker_address"></a>`kafka_broker_address`
+
+Data type: `String`
+
+String giving broker address
+
+Default value: `'sasquatch-tts-kafka-bootstrap.lsst.codes:9094'`
+
+##### <a name="-ccs_sal--kafka_registry_url"></a>`kafka_registry_url`
+
+Data type: `String`
+
+String giving registry URL
+
+Default value: `'https://tucson-teststand.lsst.codes/schema-registry'`
+
+##### <a name="-ccs_sal--kafka_sasl_username"></a>`kafka_sasl_username`
+
+Data type: `String`
+
+String giving SASL username
+
+Default value: `'username'`
+
+##### <a name="-ccs_sal--kafka_sasl_password"></a>`kafka_sasl_password`
+
+Data type: `String`
+
+String giving SASL password
+
+Default value: `'password'`
+
+##### <a name="-ccs_sal--kafka_templates_directory"></a>`kafka_templates_directory`
+
+Data type: `String`
+
+String giving location of templates directory
+
+Default value: `'/home/tonyj/avro-templates'`
 
 ##### <a name="-ccs_sal--prefix_service"></a>`prefix_service`
 

--- a/files/setup-sal
+++ b/files/setup-sal
@@ -1,0 +1,7 @@
+# -*- mode: sh; -*-
+# This file is managed by Puppet; changes may be overwritten.
+if [ -z "${LSST_USE_KAFKA}" ]; then
+    source /etc/ccs/setup-sal5
+else
+    source /etc/ccs/setup-kafka
+fi

--- a/manifests/etc.pp
+++ b/manifests/etc.pp
@@ -2,6 +2,9 @@
 #   Configure /etc for CCS/SAL
 #
 class ccs_sal::etc {
+  $dds = $ccs_sal::dds
+  $kafka = $ccs_sal::kafka
+
   $dir = '/etc/ccs'
 
   $attributes = {
@@ -13,24 +16,55 @@ class ccs_sal::etc {
   $ptitle = regsubst($title, '::.*', '', 'G')
 
   $salfile = 'setup-sal5'
+  $kafka_salfile = 'setup-sal-kafka'
+  $prefile = 'setup-sal'
 
-  file { "${dir}/${salfile}":
-    ensure  => file,
-    content => epp("${ptitle}/${salfile}.epp", {
-        'domain'    => $ccs_sal::dds_domain,
-        'interface' => $ccs_sal::dds_interface,
-        'home'      => $ccs_sal::ospl_home,
-      },
-    ),
-    *       => $attributes,
+  file { "${dir}/${prefile}":
+    ensure => file,
+    source => "puppet:///modules/${ptitle}/${prefile}",
+    *      => $attributes,
   }
 
-  ['ospl-shmem.xml', 'QoS.xml'].each|$thing| {
-    $file = "${dir}/${thing}"
-    file { $file:
-      ensure => file,
-      source => "puppet:///modules/${ptitle}/${thing}",
-      *      => $attributes,
+  if $kafka {
+    $implementation = 'system.property.org.lsst.sal.implementation=kafka'
+  } else {
+    $implementation = undef
+  }
+
+  if $kafka {
+    file { "${dir}/${kafka_salfile}":
+      ensure  => file,
+      content => epp("${ptitle}/${kafka_salfile}.epp", {
+          'templates_directory' => $ccs_sal::kafka_templates_directory,
+          'broker_address'      => $ccs_sal::kafka_broker_address,
+          'sasl_username'       => $ccs_sal::kafka_sasl_username,
+          'sasl_password'       => $ccs_sal::kafka_sasl_password,
+          'registry_url'        => $ccs_sal::kafka_registry_url,
+        },
+      ),
+      *       => $attributes,
+    }
+  }
+
+  if $dds {
+    file { "${dir}/${salfile}":
+      ensure  => file,
+      content => epp("${ptitle}/${salfile}.epp", {
+          'domain'    => $ccs_sal::dds_domain,
+          'interface' => $ccs_sal::dds_interface,
+          'home'      => $ccs_sal::ospl_home,
+        },
+      ),
+      *       => $attributes,
+    }
+
+    ['ospl-shmem.xml', 'QoS.xml'].each|$thing| {
+      $file = "${dir}/${thing}"
+      file { $file:
+        ensure => file,
+        source => "puppet:///modules/${ptitle}/${thing}",
+        *      => $attributes,
+      }
     }
   }
 
@@ -39,20 +73,26 @@ class ccs_sal::etc {
     $file = "${dir}/${instrument}-ocs-${thing}.app"
     file { $file:
       ensure  => file,
-      content => "system.pre-execute=${salfile}\n",
+      content => epp("${ptitle}/ocs-app.epp", {
+          'prefile' => $prefile,
+          'extra'   => $implementation,
+        },
+      ),
       *       => $attributes,
     }
   }
 # lint:endignore
 
-  ## Stop tmpfiles.d removing opensplice sockets.
-  $tmpfiles_conf = 'ccs-ospl.conf'
+  if $dds {
+    ## Stop tmpfiles.d removing opensplice sockets.
+    $tmpfiles_conf = 'ccs-ospl.conf'
 
-  file { "/etc/tmpfiles.d/${tmpfiles_conf}":
-    ensure => file,
-    source => "puppet:///modules/${ptitle}/${tmpfiles_conf}",
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
+    file { "/etc/tmpfiles.d/${tmpfiles_conf}":
+      ensure => file,
+      source => "puppet:///modules/${ptitle}/${tmpfiles_conf}",
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,12 +6,27 @@
 #   "ts_sal_utils" => "ts_sal_utils-4.0.0-1.x86_64.rpm"
 # @param ospl_home
 #   String giving OSPL_HOME.
+# @param dds
+#   Boolean; if true install DDS support
 # @param dds_domain
 #   String giving LSST_DDS_DOMAIN (eg base)
 # @param dds_interface
 #   String giving name of SAL interface (eg somehost-dds)
 # @param instrument
 #   String giving instrument (eg comcam).
+# @param kafka
+#   Boolean; if true install Kafka support
+#   kafka will be used.
+# @param kafka_broker_address
+#   String giving broker address
+# @param kafka_registry_url
+#   String giving registry URL
+# @param kafka_sasl_username
+#   String giving SASL username
+# @param kafka_sasl_password
+#   String giving SASL password
+# @param kafka_templates_directory
+#   String giving location of templates directory
 # @param prefix_service
 #   Boolean; if false do not prefix systemctl services with the instrument.
 # @param rpm_repo
@@ -29,9 +44,16 @@ class ccs_sal (
   Hash[String,String,1] $rpms,
   ## Change the following in hiera, not here.
   String $ospl_home = '/opt/OpenSpliceDDS/VX.Y.Z/example/example',
+  Boolean $dds = true,
   String $dds_domain = 'summit',
   String $dds_interface = 'localhost-dds',
   String $instrument = 'comcam',
+  Boolean $kafka = false,
+  String $kafka_broker_address = 'sasquatch-tts-kafka-bootstrap.lsst.codes:9094',
+  String $kafka_registry_url = 'https://tucson-teststand.lsst.codes/schema-registry',
+  String $kafka_sasl_password = 'password',
+  String $kafka_sasl_username = 'username',
+  String $kafka_templates_directory = '/home/tonyj/avro-templates', # FIXME
   Boolean $prefix_service = true,
   ## Old: http://www.slac.stanford.edu/~gmorris/lsst/pkgarchive
   String $rpm_repo = 'https://repo-nexus.lsst.org/nexus/repository/ts_yum/releases',
@@ -43,7 +65,9 @@ class ccs_sal (
   Optional[String] $rpm_user = undef,
   Optional[String] $rpm_pass = undef,
 ) {
-  include ccs_sal::rpms
+  if $dds {
+    include ccs_sal::rpms
+  }
   include ccs_sal::etc
   include ccs_sal::service
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,6 +2,8 @@
 #   Manage systemd service files for CCS/SAL
 #
 class ccs_sal::service {
+  $dds = $ccs_sal::dds
+
   $common_vars = {
     user    => 'ccs',
     group   => 'ccs',
@@ -49,7 +51,11 @@ class ccs_sal::service {
   }
 
   ## FIXME ccs_software module can also manage basic services.
-  $services = [$opensplice, $ocs_bridge, $mcm]
+  if $dds {
+    $services = [$opensplice, $ocs_bridge, $mcm]
+  } else {
+    $services = [$ocs_bridge, $mcm]
+  }
 
   $services.each | $hash | {
     $service  = $hash['service']

--- a/templates/ocs-app.epp
+++ b/templates/ocs-app.epp
@@ -1,0 +1,5 @@
+<%- | String $prefile, Optional[String] $extra = undef | -%>
+system.pre-execute=<%= $prefile %>
+<% unless $extra =~ Undef { -%>
+<%= $extra %>
+<% } -%>

--- a/templates/setup-sal-kafka.epp
+++ b/templates/setup-sal-kafka.epp
@@ -1,0 +1,14 @@
+<%- | String $templates_directory,
+      String $broker_address,
+      String $sasl_username,
+      String $sasl_password,
+      String $registry_url,
+| -%>
+# This file is managed by Puppet; changes may be overwritten.
+export LSST_AVRO_TEMPLATES=<%= $templates_directory %>
+export LSST_KAFKA_BROKER_ADDR=<%= $broker_address %>
+export LSST_SECURITY_PROTOCOL=SASL_SSL
+export LSST_SASL_USERNAME=<%= $sasl_username %>
+export LSST_SASL_PASSWORD="<%= $sasl_password %>"
+export LSST_TOPIC_SUBNAME=sal
+export LSST_SCHEMA_REGISTRY_URL=<%= $registry_url %>


### PR DESCRIPTION
New class parameters:
(dds, kafka) boolean switches
(kafka_broker_address, kafka_registry_url, kafka_sasl_password) (kafka_sasl_username, kafka_templates_directory) strings with kafka values

(rpms) nothing to install when not using dds.
(services) no opensplice when not using dds.
(etc) add kafka setup file when relevant, skip dds when not. Add kafka line to .app files when relevant. Use a template for app files. Always use setup-sal as the pre-execute file.

(files/setup-sal) new file
(templates/ocs-app.epp, templates/setup-sal-kafka.epp) new templates