### PR TITLE
fix example

### DIFF
--- a/examples/basic.pp
+++ b/examples/basic.pp
@@ -13,6 +13,6 @@ group { 'ccsadm':
 
 class { 'ccs_sal':
   rpms => {
-    ts_sal_utils => 'ts_sal_utils-7.4.0-1.x86_64.rpm',
+    ts_sal_utilsKafka => 'ts_sal_utilsKafka-10.1.1-1.x86_64.rpm',
   },
 }


### PR DESCRIPTION
The ts_yum repo doesn't retain old package versions. It seems that ts_sal_utils no longer exists, but ts_sal_utilsKafka does.